### PR TITLE
fixed codecept options

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,14 +38,8 @@ module.exports = (api, options) => {
     // create runner
     let runner = new codecept(conf, { ...opts, ...args });
     
-    // initialize codeceptjs in tests/e2e
-    runner.initGlobals(api.getCwd());
-    
-    // create helpers, support files, mocha
-    container.create(conf, opts);
-    
-    // initialize listeners
-    runner.runHooks();
+    // initialize codeceptjs
+    runner.init(api.getCwd());
     
     // load tests
     runner.loadTests();

--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ module.exports = (api, options) => {
 
     const server = await runServer(args.serve);   
     
-    const { container, config, codecept } = require('codeceptjs');
+    const { config, codecept } = require('codeceptjs');
     const { setHeadlessWhen } = require('@codeceptjs/configure');
       
     const opts = { steps: true };


### PR DESCRIPTION
`yarn test:e2e -h`
> ...
>   All CodeceptJS CLI options are also supported:
>   https://codecept.io/commands#run

But options like --debug and others did not work because of `container.create(conf, opts);` does not use options set here  `let runner = new codecept(conf, { ...opts, ...args })`

also why steps are enabled by default how can I disable them?